### PR TITLE
Provide option to customize http headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,7 +91,8 @@ class Nominatim {
         
         axios.get(url, { 
           params: queryObject.plainObject(), 
-          headers: this.options.headers })
+          headers: this.options.headers
+        })
           .then((response) => {
             resolve(response.data)
           })

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ class Nominatim {
       customUrl: undefined, // if you want to host your own nominatim
       cache: true,
       delay: 1000, // Delay between requests
+      headers: {} // customize the http headers
     }
 
     const queryDefaults = {
@@ -87,8 +88,10 @@ class Nominatim {
           resolve(cachedResponse)
           return
         }
-
-        axios.get(url, { params: queryObject.plainObject() })
+        
+        axios.get(url, { 
+          params: queryObject.plainObject(), 
+          headers: this.options.headers })
           .then((response) => {
             resolve(response.data)
           })


### PR DESCRIPTION
Since some Novatim instances require you to provide a custom referer and user agent, we should provide the option to customize http headers. This PR enables top set them like this:

```js
const Nominatim = require('nominatim-geocoder')

const geocoder = new Nominatim({
  delay: 1000,
  headers: {
    Referer: 'https://www.example.org/',
    'User-Agent': 'My geocoder script',
  },
})
```